### PR TITLE
Add support AG-CX10

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -375,6 +375,7 @@ export class P2CameraConnection extends EventEmitter<P2Events> {
         const rcName = {
             'HC-X2': 'RC_SemiProApp_NodeJS',
             'HC-X20': 'RC_SemiProApp_NodeJS',
+            'AG-CX10': 'RC_AllianceApp',
             'CX350': 'RC_AllianceApp',
             'EVA1': 'RC_AllianceApp'
         }[this.envInfo.device.modelName] ?? 'RC_P2Package_NodeJS';


### PR DESCRIPTION
The fallback rcName would not work for the AG-CX10 and results in an error claiming that the "Remote setting is Disabled". Because this is definitely not the case, I analysed the traffic between the HC ROP Android app and the Camera and came across the difference in the rcName. Now, it is also possible to  connect and control the AG-CX10.